### PR TITLE
Update controller logic to support Redactor v4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Rails 3.2 Integration for Redactor (Devise Edition)
 
+## Updated to support Redactor v4.x
+
 The redactor-rails gem integrates the [Redactor](http://redactorjs.com/) editor with the Rails 3.2 asset pipeline.
 
 This gem bundles Redactor version 10.0.4 which is the most recent version as of January 9, 2015. Check [Redactor's changelog](http://imperavi.com/redactor/log/) for further updates.

--- a/app/controller/redactor_rails/documents_controller.rb
+++ b/app/controller/redactor_rails/documents_controller.rb
@@ -8,14 +8,46 @@ class RedactorRails::DocumentsController < ApplicationController
   end
 
   def create
-    @document = RedactorRails.document_model.new
-
-    file = params[:file]
-    @document.data = RedactorRails::Http.normalize_param(file, request)
-    if @document.has_attribute?(:"#{RedactorRails.devise_user_key}")
-      @document.send("#{RedactorRails.devise_user}=", redactor_current_user)
-      @document.assetable = redactor_current_user
+    if params[:version_4].present?
+      # Redactor 4
+      process_version_4_document
+    else
+      # Legacy Redactor
+      process_version_2_document
     end
+
+  end
+
+  private
+
+  def process_version_4_document
+    files = params[:file]
+    results = {}
+    file_counter = 0
+
+    files.each do |file|
+      @document = RedactorRails.document_model.new
+      attach_document(file)
+
+      if @document.save
+        file_counter += 1
+        results["file-#{file_counter}"] = {
+          id: SecureRandom.uuid,
+          name: file.original_filename,
+          url: @document.url
+        }
+      end
+    end
+
+    render json: results
+  rescue StandardError => e
+    render json: { error: true, message: e.message }
+  end
+
+  def process_version_2_document
+    @document = RedactorRails.document_model.new
+    file = params[:file]
+    attach_document(file)
 
     if @document.save
       render json: { url: @document.url, filename: @document.filename }
@@ -24,7 +56,13 @@ class RedactorRails::DocumentsController < ApplicationController
     end
   end
 
-  private
+  def attach_document(file)
+    @document.data = RedactorRails::Http.normalize_param(file, request)
+    if @document.has_attribute?(:"#{RedactorRails.devise_user_key}")
+      @document.send("#{RedactorRails.devise_user}=", redactor_current_user)
+      @document.assetable = redactor_current_user
+    end
+  end
 
   def redactor_authenticate_user!
     if RedactorRails.document_model.new.has_attribute?(RedactorRails.devise_user)

--- a/app/controller/redactor_rails/documents_controller.rb
+++ b/app/controller/redactor_rails/documents_controller.rb
@@ -26,11 +26,11 @@ class RedactorRails::DocumentsController < ApplicationController
     file_counter = 0
 
     files.each do |file|
+      file_counter += 1
       @document = RedactorRails.document_model.new
       attach_document(file)
 
       if @document.save
-        file_counter += 1
         results["file-#{file_counter}"] = {
           id: SecureRandom.uuid,
           name: file.original_filename,

--- a/app/controller/redactor_rails/pictures_controller.rb
+++ b/app/controller/redactor_rails/pictures_controller.rb
@@ -26,11 +26,11 @@ class RedactorRails::PicturesController < ApplicationController
     file_counter = 0
 
     files.each do |file|
+      file_counter += 1
       @picture = RedactorRails.picture_model.new
       attach_picture(file)
 
       if @picture.save
-        file_counter += 1
         results["file-#{file_counter}"] = {
           id: SecureRandom.uuid,
           url: @picture.url(:content)

--- a/app/controller/redactor_rails/pictures_controller.rb
+++ b/app/controller/redactor_rails/pictures_controller.rb
@@ -8,14 +8,46 @@ class RedactorRails::PicturesController < ApplicationController
   end
 
   def create
+    if params[:version_4].present?
+      # Redactor 4
+      process_version_4_picture
+    else
+      # Legacy Redactor
+      process_version_2_picture
+    end
+
+  end
+
+  private
+
+  def process_version_4_picture
+    files = params[:file]
+    results = {}
+    file_counter = 0
+
+    files.each do |file|
+      @picture = RedactorRails.picture_model.new
+      attach_picture(file)
+
+      if @picture.save
+        file_counter += 1
+        results["file-#{file_counter}"] = {
+          id: SecureRandom.uuid,
+          url: @picture.url(:content)
+        }
+      end
+    end
+
+    render json: results
+  rescue StandardError => e
+    render json: { error: true, message: e.message }
+  end
+
+  def process_version_2_picture
     @picture = RedactorRails.picture_model.new
 
     file = params[:file]
-    @picture.data = RedactorRails::Http.normalize_param(file, request)
-    if @picture.has_attribute?(:"#{RedactorRails.devise_user_key}")
-      @picture.send("#{RedactorRails.devise_user}=", redactor_current_user)
-      @picture.assetable = redactor_current_user
-    end
+    attach_picture(file)
 
     if @picture.save
       render json: { url: @picture.url(:content) }
@@ -24,7 +56,13 @@ class RedactorRails::PicturesController < ApplicationController
     end
   end
 
-  private
+  def attach_picture(file)
+    @picture.data = RedactorRails::Http.normalize_param(file, request)
+    if @picture.has_attribute?(:"#{RedactorRails.devise_user_key}")
+      @picture.send("#{RedactorRails.devise_user}=", redactor_current_user)
+      @picture.assetable = redactor_current_user
+    end
+  end
 
   def redactor_authenticate_user!
     if RedactorRails.picture_model.new.has_attribute?(RedactorRails.devise_user)


### PR DESCRIPTION
In order to support Redactor 4.x we need to update this gem to account for a few things:

1. The expected request format
2. The expected response format
3. The expected error format
4. Maintaining backwards compatibility with Redactor 2.x (still used widely across the platform)
5. Multi-file uploads for files 

## Redactor Documentation References
- https://imperavi.com/redactor/docs/get-started/upload-images/
- https://imperavi.com/redactor/plugins/filelink

## The Request Format

Previously, the gem expected a single file to be passed as a post parameter. With the new version we need to expect an array of files as the post param, to support multi-file uploads.

## The Response Format
After uploading, the server-side script should generate a JSON as the response, like this for single upload:

```json
{
    "file": {
        "url": "image-url.jpg",
        "id": "some-id"
    }
}
```
And like this for multi-file uploads:

```json
{
    "file-1": {
        "url": "image-url-1.jpg",
        "id": "some-id"
    },
    "file-2": {
        "url": "image-url-2.jpg",
        "id": "some-id"
    }
}
```

## The Error Response Format

If the upload fails the server must return JSON with an error key like this:

```json
{
    "error": true,
    "message": "Something went wrong..."
}

```

## Backwards Compatibility with Version 2.x

In order to maintain backwards compatibility with the existing 2.x version, we will require a `version_4` parameter to be passed in, to indicate to the gem that we should use the new request/response format for processing.

This gets passed in as part of the configuration of Redactor like this:

```javascript
 document.addEventListener('DOMContentLoaded', function() {
      RedactorEditor('#event_about_text', {
          plugins: ['alignment', 'fontcolor', 'fontsize', 'fontfamily', 'imageresize', 'filelink'],
          theme: 'light',
          source: false,
          minHeight: '300px',
          image: {
              upload: '/redactor_rails/pictures?',
              data: {
                  version_4: true,
                  authenticity_token: document.querySelector("meta[name=csrf-token]").content,
                  multiple: true
              }
          },
          filelink: {
              upload: '/redactor_rails/documents?',
              data: {
                  version_4: true,
                  authenticity_token: document.querySelector("meta[name=csrf-token]").content,
                  multiple: true // Not currently supported, but assuming they follow the same pattern as images
              }

          }
      })
  })
```

## Support for Uploading Multiple Files

Currently, the editor doesn't support inserting more than a single file link, but it does support uploading multiple files. This is a limitation on the redactor side, which I'm going to contact them about, but assuming they follow the same pattern for multiple image uploads, our code will already support this when they release the ability to upload and link multiple files. Currently, you can upload multiple files, but only the last one gets inserted as a link within the editor.
